### PR TITLE
chore: increment package version to 2.0.0-dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cordova/eslint-config",
-  "version": "1.0.0",
+  "version": "2.0.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cordova/eslint-config",
-  "version": "1.0.0",
+  "version": "2.0.0-dev",
   "description": "Cordova ESLint Config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
While version 1 marked the greatest common divisor of ESLint configs in place in our repos at the moment, version 2 will be in our upcoming next-major releases.