### PR TITLE
docs: use new 'overrides' directive in sample config

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm i -D @cordova/eslint-config
 # In package.json
 {
   "scripts": {
-    "eslint": "eslint ."
+    "lint": "eslint ."
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -45,17 +45,16 @@ npm i -D @cordova/eslint-config
 ```yml
 # In .eslintrc.yml
 root: true
+
 extends: '@cordova/eslint-config/node'
-```
 
-```yml
-# In spec/.eslintrc.yml
-extends: '@cordova/eslint-config/node-tests'
-```
+overrides:
 
-```yml
-# In cordova-js-src/.eslintrc.yml
-extends: '@cordova/eslint-config/browser'
+- files: [spec/**/*.js]
+  extends: '@cordova/eslint-config/node-tests'
+
+- files: [cordova-js-src/**/*.js]
+  extends: '@cordova/eslint-config/browser'
 ```
 
 ## Reference


### PR DESCRIPTION
The new `overrides` directive allows us to configure different linting
rule sets for all the files in a repo from the root `.eslintrc`. This
commit updates the docs to use this kind of configuration setup.