### PR TITLE
feat: make base rules stricter & closer to semistandard

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -28,9 +28,6 @@ module.exports = {
 
     rules: {
         indent: ['error', 4],
-        camelcase: 'off',
-        'padded-blocks': 'off',
-        'operator-linebreak': 'off',
-        'no-throw-literal': 'off'
+        camelcase: 'off'
     }
 };


### PR DESCRIPTION
This removes all exceptions from `semistandard` we had in place, except
for `camelcase: off`. This step had already been taken in some of our
repos (e.g. `cordova-js`, `cordova-common`) before.

`camelcase` stays disabled for now as enabling & enforcing it would have
the potential of creating many conflicts with existing work in progress.