### PR TITLE
dep!: drop eslint-plugin-standard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "eslint-config-standard": "^16.0.3",
         "eslint-plugin-import": "^2.24.2",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^5.1.0",
-        "eslint-plugin-standard": "^5.0.0"
+        "eslint-plugin-promise": "^5.1.0"
       },
       "devDependencies": {
         "jasmine": "^3.9.0",
@@ -1332,29 +1331,6 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-standard": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
-      "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
-      "deprecated": "standard 16.0.0 and eslint-config-standard 16.0.0 no longer require the eslint-plugin-standard package. You can remove it from your dependencies with 'npm rm eslint-plugin-standard'. More info here: https://github.com/standard/standard/issues/1316",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "peerDependencies": {
-        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -4573,12 +4549,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.1.0.tgz",
       "integrity": "sha512-NGmI6BH5L12pl7ScQHbg7tvtk4wPxxj8yPHH47NvSmMtFneC077PSeY3huFj06ZWZvtbfxSPt3RuOQD5XcR4ng==",
-      "requires": {}
-    },
-    "eslint-plugin-standard": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
-      "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
       "requires": {}
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^5.1.0",
-    "eslint-plugin-standard": "^5.0.0"
+    "eslint-plugin-promise": "^5.1.0"
   },
   "engines": {
     "node": ">=12.0.0"


### PR DESCRIPTION
This PR drops the `eslint-plugin-standard` dependency.

For more information, read:

* https://github.com/standard/standard/issues/1316
* https://www.npmjs.com/package/eslint-plugin-standard