### PR TITLE
chore: relax node engine requirement for external users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "nyc": "^15.1.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-promise": "^6.1.1"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
   },
   "devDependencies": {
     "jasmine": "^4.5.0",


### PR DESCRIPTION
Match ESLint's node engine requirement for external users.
Makes the packages usable for projects outside of Cordova.