### PR TITLE
feat: disable no-var for browser linting

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -20,5 +20,9 @@
 module.exports = {
     env: {
         browser: true
+    },
+
+    rules: {
+        'no-var': 0
     }
 };


### PR DESCRIPTION
Disable no-var rule for browsers.

Per Cordova-iOS todo comment: https://github.com/apache/cordova-ios/blob/master/.eslintrc.yml#L28