### PR TITLE
ci(workflow): improved actions (pinning, license, node permission & on blocks, codeql)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,28 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-#  KIND, either express or implied.  See the License for the
+# KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
 
 name: Node CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+    branches:
+      - '*'
+
+permissions:
+  contents: read
+  security-events: write
 
 jobs:
   test:
@@ -27,7 +37,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -40,12 +50,24 @@ jobs:
           node --version
           npm --version
 
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript
+          queries: security-and-quality
+          config: |
+            paths-ignore:
+              - coverage
+              - node_modules
+
       - name: Run npm install and test
         run: npm cit
         env:
           CI: true
 
-      - uses: codecov/codecov-action@v4
+      - uses: github/codeql-action/analyze@v3
+
+      # v4.6.0
+      - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
         if: success()
         with:
           name: ${{ runner.os }} node.js ${{ matrix.node-version }}

--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -6,18 +6,27 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-#  KIND, either express or implied.  See the License for the
+# KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
 
 name: Release Auditing
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+    branches:
+      - '*'
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -28,12 +37,12 @@ jobs:
       - uses: actions/checkout@v4
 
       # Check license headers
-      - uses: erisu/apache-rat-action@2840c4d69521d23ab0cfd346e14406d884c656da
+      - uses: erisu/apache-rat-action@3127a8c18f3bb10e91c60e835144085b31c5c463
 
       # Setup environment with node
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       # Install node packages
       - name: npm install packages


### PR DESCRIPTION
- Updated GH Action Workflows
  - Fix license header formatting
  - Expanded the `on` block to ignore `dependabot/**`
  - Added `permissions` block
    - `contents` with permission `read`
    - `security-events` with permission `write` to be able to post security reports from codeql
  - Added CodeQL
  - Added pinning for `codecov-action`
  - Updated `apache-rat-action` pinning`
  - Updated release audit workflow to use node 20.