### PR TITLE
chore: bump node requirement >=20.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "jasmine": "^5.8.0"
       },
       "engines": {
-        "node": ">=20.5.0"
+        "node": ">=20.9.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "globals": "^16.3.0"
   },
   "engines": {
-    "node": ">=20.5.0"
+    "node": ">=20.9.0"
   },
   "devDependencies": {
     "c8": "^10.1.3",


### PR DESCRIPTION
It looks like we forgot to revisit and confirm the Node.js version requirement after upgrading to ESLint 9.

Below is an example of what happens when attempting to run `npm i` with Node.js `v20.5.0`. The actual output would include additional ESLint-related packages as well:

```log
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'eslint@9.31.0',
npm WARN EBADENGINE   required: { node: '^18.18.0 || ^20.9.0 || >=21.1.0' },
npm WARN EBADENGINE   current: { node: 'v20.5.0', npm: '9.8.0' }
npm WARN EBADENGINE }
```

Previously, we updated the minimum Node.js version to `>=20.5.0` across the board. At that time, we verified this requirement by checking `package-lock.json` files in various repos (e.g., `cordova-ios`) and confirmed that `>=20.5.0` would be appropriate. However, ESLint 9 was not yet included in our dependencies at that point.

It should now be safe to raise our minimum Node.js version to `>=20.9.0`, since no packages (aside from the Cordova-iOS 8 beta) have been officially released with the 20.x requirement set.

**Resources:**
- [ESLint 9 Release Notes](https://github.com/eslint/eslint/releases/tag/v9.0.0)