### PR TITLE
ci: update license-checker-action

### DIFF
--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -36,7 +36,7 @@ jobs:
       # Checkout project
       - uses: actions/checkout@v4
 
-      # Check license headers
+      # Check license headers (v1.2.0)
       - uses: erisu/apache-rat-action@3127a8c18f3bb10e91c60e835144085b31c5c463
 
       # Setup environment with node
@@ -48,7 +48,8 @@ jobs:
       - name: npm install packages
         run: npm i
 
-      # Check node package licenses
-      - uses: erisu/license-checker-action@e929758f9416f30234ac454fc9054ca4b803871d
+      # Check node package licenses (v2.0.0)
+      - uses: erisu/license-checker-action@1c222d0c2f5898a4c40b8bd6fd6888650bd6f68a
         with:
           license-config: 'licence_checker.yml'
+          include-asf-category-a: true

--- a/.ratignore
+++ b/.ratignore
@@ -1,2 +1,3 @@
 \.(.*)
+coverage
 node_modules

--- a/licence_checker.yml
+++ b/licence_checker.yml
@@ -15,47 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Compiled list of allowed 3RD PARTY LICENSES from:
-#
-# ASF CATEGORY A: WHAT CAN WE INCLUDE IN AN ASF PROJECT
-# https://www.apache.org/legal/resolved.html#category-a
-#
-# Licenses converted into the SPDX standardized short identifier format.
-# https://spdx.org/licenses/
-allowed-licenses:
-  - 0BSD
-  - AFL-3.0
-  - Apache-1.1
-  - Apache-2.0
-  - APAFML
-  - BlueOak-1.0.0
-  - BSD-2-Clause
-  - BSD-3-Clause
-  - BSD-3-Clause-LBNL
-  - BSL-1.0
-  - CC-PDDC
-  - CC0-1.0
-  - EPICS
-  - HPND
-  - ICU
-  - ISC
-  - MIT
-  - MIT-0
-  - MS-PL
-  - MulanPSL-2.0
-  - NCSA
-  - OGL-UK-3.0
-  - PHP-3.01
-  - PostgreSQL
-  - PSF-2.0
-  - Python-2.0
-  - SMLNJ
-  - Unicode-DFS-2016
-  - Unlicense
-  - UPL-1.0
-  - W3C
-  - WTFPL
-  - X11
-  - Xnet
-  - Zlib
-  - ZPL-2.0
+# Empty for the release audit workflow.
+# The `license-config` is required even if there are no custom configs


### PR DESCRIPTION
Update `license-checker-action` to use latest release (pinned to commit hash of [v2.0.0](https://github.com/erisu/license-checker-action/releases/tag/v2.0.0))
- Set flag `include-asf-category-a` to use the [action's pre-compiled list](https://github.com/erisu/license-checker-action/blob/v2.0.0/allowed-licenses-groups.json#L2-L39)
- Cleared out the `licence_checker.yml` but kept empty file for the action to pass.